### PR TITLE
vim: fix huge width for nvim-tree

### DIFF
--- a/vim/.config/nvim/lua/plugins/nvim-tree.lua
+++ b/vim/.config/nvim/lua/plugins/nvim-tree.lua
@@ -111,7 +111,7 @@ nvim_tree.setup({
             },
         },
         special_files = { 'Cargo.toml', 'Makefile', 'README.md', 'readme.md' },
-        symlink_destination = true,
+        symlink_destination = false,
     },
     hijack_directories = {
         enable = true,


### PR DESCRIPTION
Together with auto width, showing symlinks path was making sidebar to wide.
