### PR TITLE
dot/termux-fixes

### DIFF
--- a/vim/.config/nvim/lua/lsp/init.lua
+++ b/vim/.config/nvim/lua/lsp/init.lua
@@ -13,6 +13,7 @@ if not lspconfig_ok
     or not null_ls_ok
 then
     print('lsp/init.lua: require failed')
+    return
 end
 
 -- Lsp server name is same as file name with config.

--- a/zsh/.config/zsh/aliases.zsh
+++ b/zsh/.config/zsh/aliases.zsh
@@ -1,11 +1,17 @@
 #!/usr/bin/env zsh
 
 install() {
-    echo "Installing $1"
     if hash pacman 2>/dev/null; then
+        echo "Installing $1"
         sudo pacman -S $1
     elif hash pkg 2>/dev/null; then
-        pkg $1
+        case $1 in
+            xclip | fping)
+                return 
+                ;;
+        esac
+        echo "Installing $1"
+        pkg install $1
     fi
     zsh
 }


### PR DESCRIPTION
First run of ZSH was failing on termux due to missing packages in pkg repo.
First run of NEOVIM was failing because there was missing return in error handler.

- fix installation process for aliases in termux (deb) env
- Add missing return in early exit error handler.
